### PR TITLE
Disable game-altering features by default

### DIFF
--- a/mm2hook.ini
+++ b/mm2hook.ini
@@ -30,7 +30,7 @@ PoliceAcademyFunding=1        ; Police will only chase you if you are exceeding 
 DefaultSpeedLimit=12.25       ; Default speed limit for police to use in areas with no defined speed limit. (12.25 = ~35MPH)
 SpeedLimitTolerance=1.125     ; How much leverage the police will give speeding perps before chasing them. (1.0 = very strict)
 MaximumCopsLimit=3            ; Limits the number of cops pursuing the player. 3 = Default, 0 = Unlimited.
-BustedTarget=3                ; Controls who the police will be able to bust. 0 = None, 1 = Player, 2 = Opponents, 3 = Both.
+BustedTarget=0                ; Controls who the police will be able to bust. 0 = None, 1 = Player, 2 = Opponents, 3 = Both.
 BustedMaxSpeed=10.0           ; Maximum speed that a police car will be able to bust you at. If you are going faster than this, they cannot arrest you.
 BustedTimeout=1.0             ; The amount of time you can be under the BustedMaxSpeed before a cop can arrest you.
 NFSMWStyleEscape=0            ; Changes the way the player escape from cops, in a way that resembles how NFS Most Wanted did it.
@@ -49,13 +49,13 @@ HornSirenThreshold=0.15       ; Threshold in seconds for how long the horn butto
 ExplosionSound=1              ; Enables explosion sound effect for player's emergency vehicles if they're damaged out with activated siren, it also turns off the engine for all cars if they're destroyed.
 ReflectionsOnBreakables=1	  ; Enables reflections on breakable parts, such as mirrors.
 ReflectionsOnCarParts=0       ; Enables reflections on car parts such as wheels and fenders. Note that addon cars will have shiny tires with this enabled if they are not set up correctly.
-MM1StyleTransmission=1        ; Improves transmission physics with more realistic behavior.
-MM1StyleAutoReverse=1         ; Improves auto reverse system with behavior resembling Midtown Madness 1.
+MM1StyleTransmission=0        ; Improves transmission physics with more realistic behavior.
+MM1StyleAutoReverse=0         ; Improves auto reverse system with behavior resembling Midtown Madness 1.
 EnableHudArrowStyles=1        ; Enables the unused alternative style hud arrows for Blitz and Crash Course game modes.
 NFSMWStyleTotaledCar=0        ; Deactivates car lights if it's destroyed.
 EscapeDeepWater=1             ; Enables a new check which allows you to continue driving if you fall into deep water, but manage to escape afterwards.
 ResetToNearestLocation=0      ; Resets you to the nearest valid location if you fall into deep water.
-PhysicalEngineDamage=1        ; Damage affects engine torque when the engine spews smoke and that means the vehicle will have less acceleration and less top speed.
+PhysicalEngineDamage=0        ; Damage affects engine torque when the engine spews smoke and that means the vehicle will have less acceleration and less top speed.
 EnableMouseBar=0              ; Enables showing up the mouse bar for all input devices, this style is similar to the steering bar in Gran Turismo games.
 SwitchFromMPH2KPH=0           ; Allows you to switch hud speedometer from MPH to KPH.
 MM1StyleFlipOver=0            ; Modifies the way the car flips over itself in a way that resembles how Midtown Madness 1 did it.


### PR DESCRIPTION
Where possible, the default mm2hook settings should preserve the vanilla game experience.