### PR TITLE
Add custom lt_glow textures support for player and traffic vehicles

### DIFF
--- a/src/events/dispatcher.cpp
+++ b/src/events/dispatcher.cpp
@@ -17,7 +17,6 @@ void GameEventDispatcher::onGameInit()
 {
     if (MM2Lua::IsEnabled())
         MM2Lua::OnGameInit();
-    dgBangerInstanceHandler::Reset();
 }
 
 void GameEventDispatcher::onChatMessage(char * message)

--- a/src/handlers/feature_handlers.cpp
+++ b/src/handlers/feature_handlers.cpp
@@ -5201,6 +5201,25 @@ void vehCarModelFeatureHandler::DrawHeadlights(bool rotate)
     if (bothLightsBroken)
         return;
 
+    bool glowLoaded = false;
+    gfxTexture* headlightTexture;
+
+    //first time texture load
+    if (!glowLoaded) {
+        headlightTexture = gfxGetTexture("lt_glow_headlight", true);
+        glowLoaded = true;
+    }
+
+    //prepare glow texture
+    gfxTexture* lastTexture = ltLight::GlowTexture;
+    bool swappedTexture = false;
+
+    //swap texture if it exists
+    if (lastTexture != NULL && headlightTexture != NULL) {
+        swappedTexture = true;
+        ltLight::GlowTexture = headlightTexture;
+    }
+
     auto carMatrix = model->getCarMatrix();
 
     float rotationAmount = vehCarModel::HeadlightFlashingSpeed;
@@ -5253,6 +5272,11 @@ void vehCarModelFeatureHandler::DrawHeadlights(bool rotate)
         light->DrawGlow(camPosition);
     }
     ltLight::DrawGlowEnd();
+
+    //reset glow texture
+    if (swappedTexture) {
+        ltLight::GlowTexture = lastTexture;
+    }
 }
 
 void vehCarModelFeatureHandler::DrawExtraHeadlights(bool rotate)
@@ -5271,6 +5295,25 @@ void vehCarModelFeatureHandler::DrawExtraHeadlights(bool rotate)
     bool bothLightsBroken = !(model->getEnabledElectrics(2) || model->getEnabledElectrics(3));
     if (bothLightsBroken)
         return;
+
+    bool glowLoaded = false;
+    gfxTexture* headlightTexture;
+
+    //first time texture load
+    if (!glowLoaded) {
+        headlightTexture = gfxGetTexture("lt_glow_headlight", true);
+        glowLoaded = true;
+    }
+
+    //prepare glow texture
+    gfxTexture* lastTexture = ltLight::GlowTexture;
+    bool swappedTexture = false;
+
+    //swap texture if it exists
+    if (lastTexture != NULL && headlightTexture != NULL) {
+        swappedTexture = true;
+        ltLight::GlowTexture = headlightTexture;
+    }
 
     auto carMatrix = model->getCarMatrix();
 
@@ -5324,6 +5367,11 @@ void vehCarModelFeatureHandler::DrawExtraHeadlights(bool rotate)
         light->DrawGlow(camPosition);
     }
     ltLight::DrawGlowEnd();
+
+    //reset glow texture
+    if (swappedTexture) {
+        ltLight::GlowTexture = lastTexture;
+    }
 }
 
 void vehCarModelFeatureHandler::DrawFoglights()
@@ -5336,6 +5384,25 @@ void vehCarModelFeatureHandler::DrawFoglights()
     auto foglight0 = lvlInstance::GetGeomTableEntry(geomSetIdOffset + 75);
     if (foglight0->GetHighLOD() == nullptr)
         return;
+
+    bool glowLoaded = false;
+    gfxTexture* headlightTexture;
+
+    //first time texture load
+    if (!glowLoaded) {
+        headlightTexture = gfxGetTexture("lt_glow_headlight", true);
+        glowLoaded = true;
+    }
+
+    //prepare glow texture
+    gfxTexture* lastTexture = ltLight::GlowTexture;
+    bool swappedTexture = false;
+
+    //swap texture if it exists
+    if (lastTexture != NULL && headlightTexture != NULL) {
+        swappedTexture = true;
+        ltLight::GlowTexture = headlightTexture;
+    }
 
     auto carMatrix = model->getCarMatrix();
 
@@ -5380,6 +5447,11 @@ void vehCarModelFeatureHandler::DrawFoglights()
         }
     }
     ltLight::DrawGlowEnd();
+
+    //reset glow texture
+    if (swappedTexture) {
+        ltLight::GlowTexture = lastTexture;
+    }
 }
 
 void vehCarModelFeatureHandler::DrawSiren(const Matrix34& carMatrix)
@@ -5389,6 +5461,25 @@ void vehCarModelFeatureHandler::DrawSiren(const Matrix34& carMatrix)
 
     if (siren->getLight(0) == nullptr)
         return;
+
+    bool glowLoaded = false;
+    gfxTexture* sirenTexture;
+
+    //first time texture load
+    if (!glowLoaded) {
+        sirenTexture = gfxGetTexture("lt_glow_siren", true);
+        glowLoaded = true;
+    }
+
+    //prepare glow texture
+    gfxTexture* lastTexture = ltLight::GlowTexture;
+    bool swappedTexture = false;
+
+    //swap texture if it exists
+    if (lastTexture != NULL && sirenTexture != NULL) {
+        swappedTexture = true;
+        ltLight::GlowTexture = sirenTexture;
+    }
 
     Vector3 camPosition = *(Vector3*)&gfxRenderState::sm_Camera->m30;
 
@@ -5436,6 +5527,11 @@ void vehCarModelFeatureHandler::DrawSiren(const Matrix34& carMatrix)
         siren->getLensFlare()->Draw(lightPos, color, intensity);
     }
     siren->getLensFlare()->DrawEnd();
+
+    //reset glow texture
+    if (swappedTexture) {
+        ltLight::GlowTexture = lastTexture;
+    }
 }
 
 bool vehCarModelFeatureHandler::Collide(lvlSegment& segment, lvlIntersection* intersection, int roomId, lvlInstance* ignoreInstance, ushort instanceFlags, int collideFlags, const Vector3& lightPos)
@@ -6491,6 +6587,25 @@ void aiVehicleInstanceFeatureHandler::DrawHeadlights()
 
     Vector3 camPosition = *(Vector3*)&gfxRenderState::sm_Camera->m30;
 
+    bool glowLoaded = false;
+    gfxTexture* headlightTexture;
+
+    //first time texture load
+    if (!glowLoaded) {
+        headlightTexture = gfxGetTexture("lt_glow_ambient", true);
+        glowLoaded = true;
+    }
+
+    //prepare glow texture
+    gfxTexture* lastTexture = ltLight::GlowTexture;
+    bool swappedTexture = false;
+
+    //swap texture if it exists
+    if (lastTexture != NULL && headlightTexture != NULL) {
+        swappedTexture = true;
+        ltLight::GlowTexture = headlightTexture;
+    }
+
     ltLight::DrawGlowBegin();
 
     auto light = aiVehicleManager::Instance->getSharedLight();
@@ -6572,6 +6687,11 @@ void aiVehicleInstanceFeatureHandler::DrawHeadlights()
     }
 
     ltLight::DrawGlowEnd();
+
+    //reset glow texture
+    if (swappedTexture) {
+        ltLight::GlowTexture = lastTexture;
+    }
 }
 
 bool aiVehicleInstanceFeatureHandler::Collide(lvlSegment& segment, lvlIntersection* intersection, int roomId, lvlInstance* ignoreInstance, ushort instanceFlags, int collideFlags)

--- a/src/handlers/feature_handlers.h
+++ b/src/handlers/feature_handlers.h
@@ -256,6 +256,13 @@ public:
     static void Install();
 };
 
+class ltLightHandler {
+public:
+    MM2::ltLight* Constructor();
+    static void ShutdownLights();
+    static void Install();
+};
+
 class mmSingleRaceHandler {
 public:
     void QueueCopVoice(float a1);
@@ -295,7 +302,6 @@ public:
     void DrawShadow();
     void DrawGlow();
     bool BeginGeom(const char* a1, const char* a2, int a3);
-    static void Reset();
     static void Install();
 };
 

--- a/src/mm2_common.h
+++ b/src/mm2_common.h
@@ -531,6 +531,8 @@ namespace MM2 {
     declhook(0x4BBE30, _Func<float>, frand);
     declhook(0x4BBE50, _Func<float>, frand2);
 
+    declhook(0x4B31D0, _Func<void>, gfxFreeTexture);
+
     declhook(0x5CED24, _Type<void(*)(int, LPCSTR, va_list)>, Printer);
 
     declhook(0x5E0CC4, _Type<void(*)(void)>, __VtResumeSampling);

--- a/src/mm2_gfx.cpp
+++ b/src/mm2_gfx.cpp
@@ -34,3 +34,5 @@ declfield(gfxRenderState::m_TouchedMasks)       = 0x5CD604;
     ltLight
 */
 declfield(ltLight::GlowScale)                   = 0x5DDE9C;
+declfield(ltLight::GlowIntensity)               = 0x5DDEA0;
+declfield(ltLight::GlowTexture)                 = 0x6B4B9C;

--- a/src/mm2_gfx.h
+++ b/src/mm2_gfx.h
@@ -591,6 +591,8 @@ namespace MM2
         int unk_48;
     public:
         static hook::Type<float> GlowScale;
+        static hook::Type<float> GlowIntensity;
+        static hook::Type<gfxTexture*> GlowTexture;
 
         ANGEL_ALLOCATOR 
 


### PR DESCRIPTION
This feature allows vehicles to use their own custom lt_glow textures if they're exist otherwise they will use the default lt_glow texture.

Texture names (Player):
"lt_glow_siren" = custom siren texture.
"lt_glow_headlight" = custom headlight texture.

Texture name (Traffic):
"lt_glow_ambient" = custom headlight texture.