### PR TITLE
Revisit mmHudMap and mmIcons feature handlers

### DIFF
--- a/mm2hook.ini
+++ b/mm2hook.ini
@@ -114,6 +114,7 @@ MM1StyleHud=0                 ; Adjusts gauge and indicator positions for MM1 hu
 MM1StylePursuitBar=0          ; Changes pursuit bar appearance to MM1 hud style.
 MM1StyleShadows=0             ; Toggles shadow meshes based on the shape of the object, in the same style as MM1's prop shadows. 0 = Off, 1 = Props, 2 = Props and Peds, 3 = Props, Peds and player vehicles, 4 = Props, Peds and all vehicles
 ShadowTransparency=1          ; Enables shadow transparency for MM1 style shadow meshes. Disable if you wanna see the Opaque shape of these shadows.
+BlacknWhiteCnRTeams=0         ; Changes CnR team colors from Red & Blue to Black & White.
 #Start of light settings.
 #By default, only HEADLIGHT and SRN objects are used. These are represented by the glow effect you can see when these lights are on.
 #The settings below allow you to enable support for the original HLIGHT and SIREN objects used by Midtown Madness 1, which allow for much more flexibility in how lighting can work.
@@ -157,7 +158,7 @@ HeadBobMultiplierZ=1.0            ; Forward/backward multiplier.
 [HudMap]
 # This section allows you to enable hud map features and styles.
 # Note: You must set the hudmap's style to 'Custom' (if applicable) for any color changes to take effect.
-# Hud map colors: -1 = White, 0 = Black, 1 = Red, 2 = Blue, 3 = Green, 4 = Darker Red, 5 = Yellow, 6 = Orange, 7 = Purple, 8 = Aqua, 9 = Pink, 10 = Lighter Pink
+# Hud map colors: 0 = Black, 1 = Bright Red, 2 = Blue, 3 = Green, 4 = Red, 5 = Yellow, 6 = Orange, 7 = Purple, 8 = Cyan, 9 = Pink, 10 = White
 HudMapColorStyle=0            ; 0 = MM2, 1 = MM1, 2 = NFS Hot Pursuit II, 3 = NFS Most Wanted, 4 = NFS Carbon, 5 = Custom
 PlayerTriColor=5              ; Adjusts player triangle color. Default = 5 (Yellow).
 PlayerTriOutlineColor=0       ; Adjusts player triangle outline color. Default = 0 (Black).
@@ -169,13 +170,13 @@ OpponentTriOutlineColor=0     ; Adjusts opponent triangle outline color. Default
 [Icons]
 # This section allows you to enable icon features and styles.
 # Note: You must set the icon's style to 'Custom' (if applicable) for any color changes to take effect.
-# Icon colors: -1 = White, 0 = Blue, 1 = Green, 2 = Red, 3 = Yellow, 4 = Orange, 5 = Purple, 6 = Aqua, 7 = Pink
+# Icon colors: 0 = Blue, 1 = Green, 2 = Red, 3 = Yellow, 4 = Orange, 5 = Purple, 6 = Cyan, 7 = Pink, 8 = White, 9 = Black
 OpponentIconStyle=0           ; 0 = MM2, 1 = MM1, 2 = NFS Hot Pursuit II, 3 = NFS Most Wanted, 4 = NFS Carbon, 5 = Custom
 OpponentIconTransparency=0    ; Enables semi-transparent opponent icon.
 OpponentIconColor=5           ; Adjusts opponent icon color. Default = 5 (Purple).
 BlitzIconMultiColor=0         ; Enables having multi colors for blitz checkpoints.
 BlitzIconTransparency=0       ; Enables semi-transparent blitz checkpoint icon.
-BlitzIconColor=6              ; Adjusts blitz checkpoint icon color. Default = 6 (Aqua).
+BlitzIconColor=6              ; Adjusts blitz checkpoint icon color. Default = 6 (Cyan).
 
 [Debug]
 # This section allows you to enable various debug features. Note, these settings can negatively impact performance in some cases.

--- a/src/handlers/feature_handlers.cpp
+++ b/src/handlers/feature_handlers.cpp
@@ -2776,6 +2776,11 @@ void mmIconsFeatureHandler::Install() {
 
     // Opp Icon Blank
     InstallPatch({ 11 }, {
+       0x41AF92 + 4, // mmSingleBlitz::InitHUD
+    });
+
+    // Opp Icon Blank
+    InstallPatch({ 11 }, {
        0x4267E5 + 6, // mmMultiCR::GameMessage
     });
 

--- a/src/handlers/feature_handlers.cpp
+++ b/src/handlers/feature_handlers.cpp
@@ -30,8 +30,8 @@ static init_handler g_feature_handlers[] = {
     CreateHandler<gizFerryHandler>("gizFerry"),
     CreateHandler<gizParkedCarMgrHandler>("gizParkedCarMgr"),
 
-    CreateHandler<mmHudMapFeatureHandler>("mmHudMapFeatureHandler"),
-    CreateHandler<mmIconsHandler>("mmIconsHandler"),
+    CreateHandler<mmHudMapFeatureHandler>("mmHudMap"),
+    CreateHandler<mmIconsFeatureHandler>("mmIcons"),
     CreateHandler<mmDashViewHandler>("mmDashView"),
     CreateHandler<mmExternalViewHandler>("mmExternalView"),
     CreateHandler<mmDirSndHandler>("mmDirSnd"),
@@ -45,6 +45,7 @@ static init_handler g_feature_handlers[] = {
     CreateHandler<mmSingleCircuitHandler>("mmSingleCircuit"),
     CreateHandler<mmSingleStuntHandler>("mmSingleStunt"),
     CreateHandler<mmSingleRoamHandler>("mmSingleRoam"),
+    CreateHandler<mmTextNodeHandler>("mmTextNode"),
 
     CreateHandler<dgBangerInstanceHandler>("dgBangerInstance"),
     CreateHandler<ltLensFlareHandler>("ltLensFlare"),
@@ -2103,6 +2104,29 @@ static ConfigValue<int> cfgPoliceTriOutlineColor     ("PoliceTriOutlineColor",  
 static ConfigValue<int> cfgOpponentTriColor          ("OpponentTriColor",          7);
 static ConfigValue<int> cfgOpponentTriOutlineColor   ("OpponentTriOutlineColor",   0);
 
+static ConfigValue<bool> cfgBlacknWhiteCnRTeams("BlacknWhiteCnRTeams", false);
+
+unsigned int HudmapIconColors[16] = {
+    0xFF000000, // Black
+    0xFFFF0000, // Bright Red
+    0xFF0000EF, // Blue
+    0xFF00EF00, // Green
+    0xFFEF0000, // Red
+    0xFFFFFF00, // Yellow
+    0xFFFF5A00, // Orange
+    0xFFB400FF, // Purple
+    0xFF00FFFF, // Cyan
+    0xFFFF0390, // Pink
+
+    // Custom Colors
+    0xFFFFFFFF, // White
+    0xFFFDBF72, // Light Orange
+    0xFFC0EC42, // Light Green
+    0xFF000099, // Dark Blue
+    0xFF990000, // Dark Red
+    0xFF555555, // Grey
+};
+
 void mmHudMapFeatureHandler::DrawColoredTri(unsigned int color, const Matrix34 &matrix) {
     rglEnableDisable(RGL_DEPTH_TEST, false);
     Matrix44::Convert(gfxRenderState::sm_World, matrix);
@@ -2117,54 +2141,10 @@ void mmHudMapFeatureHandler::DrawColoredTri(unsigned int color, const Matrix34 &
     rglEnableDisable(RGL_DEPTH_TEST, true);
 }
 
-void mmHudMapFeatureHandler::DrawWhiteTri(const Matrix34 &matrix) {
-    rglEnableDisable(RGL_DEPTH_TEST, false);
-    Matrix44::Convert(gfxRenderState::sm_World, matrix);
-    gfxRenderState::m_Touched |= 0x88;
-    vglBindTexture(0);
-    vglBegin(DRAWMODE_TRIANGLELIST, 0);
-    vglCurrentColor = 0xFFFFFFFF;
-    vglVertex(0.f, 0.f, -1.f);
-    vglVertex(-0.69999999f, 0.f, 1.f);
-    vglVertex(0.69999999f, 0.f, 1.f);
-    vglEnd();
-    rglEnableDisable(RGL_DEPTH_TEST, true);
-}
-
-void mmHudMapFeatureHandler::DrawLightOrangeTri(const Matrix34 &matrix) {
-    rglEnableDisable(RGL_DEPTH_TEST, false);
-    Matrix44::Convert(gfxRenderState::sm_World, matrix);
-    gfxRenderState::m_Touched |= 0x88;
-    vglBindTexture(0);
-    vglBegin(DRAWMODE_TRIANGLELIST, 0);
-    vglCurrentColor = 0xFFFDBF72;
-    vglVertex(0.f, 0.f, -1.f);
-    vglVertex(-0.69999999f, 0.f, 1.f);
-    vglVertex(0.69999999f, 0.f, 1.f);
-    vglEnd();
-    rglEnableDisable(RGL_DEPTH_TEST, true);
-}
-
-void mmHudMapFeatureHandler::DrawLightGreenTri(const Matrix34 &matrix) {
-    rglEnableDisable(RGL_DEPTH_TEST, false);
-    Matrix44::Convert(gfxRenderState::sm_World, matrix);
-    gfxRenderState::m_Touched |= 0x88;
-    vglBindTexture(0);
-    vglBegin(DRAWMODE_TRIANGLELIST, 0);
-    vglCurrentColor = 0xFFC0EC42;
-    vglVertex(0.f, 0.f, -1.f);
-    vglVertex(-0.69999999f, 0.f, 1.f);
-    vglVertex(0.69999999f, 0.f, 1.f);
-    vglEnd();
-    rglEnableDisable(RGL_DEPTH_TEST, true);
-}
-
-hook::Type<unsigned int> HudmapIconColors(0x5C4740);
-hook::Type<Vector3> YAXIS(0x6A3B28);
-Matrix34 mtx;
-
-void mmHudMapFeatureHandler::DrawIcon(int iconType, const Matrix34 &matrix) {
+void mmHudMapFeatureHandler::DrawIcon(int iconType, const Matrix34& matrix) {
     auto hudmap = reinterpret_cast<mmHudMap*>(this);
+
+    Matrix34 mtx;
     mtx.Set(matrix);
 
     mtx.SetRow(1, YAXIS);
@@ -2173,38 +2153,7 @@ void mmHudMapFeatureHandler::DrawIcon(int iconType, const Matrix34 &matrix) {
     mtx.m31 += 15.f;
     mtx.Scale(hudmap->GetIconScale());
 
-    uint color = *HudmapIconColors[iconType];
-
-    if (iconType >= 0)
-        DrawColoredTri(color, mtx);
-    if (iconType < 0)
-        DrawWhiteTri(mtx);
-}
-
-void mmHudMapFeatureHandler::DrawNfsMwPlayerIcon(const Matrix34 &matrix) {
-    auto hudmap = reinterpret_cast<mmHudMap*>(this);
-    mtx.Set(matrix);
-
-    mtx.SetRow(1, YAXIS);
-    mtx.Normalize();
-
-    mtx.m31 += 15.f;
-    mtx.Scale(hudmap->GetIconScale());
-
-    DrawLightOrangeTri(mtx);
-}
-
-void mmHudMapFeatureHandler::DrawNfsMwOpponentIcon(const Matrix34 &matrix) {
-    auto hudmap = reinterpret_cast<mmHudMap*>(this);
-    mtx.Set(matrix);
-
-    mtx.SetRow(1, YAXIS);
-    mtx.Normalize();
-
-    mtx.m31 += 15.f;
-    mtx.Scale(hudmap->GetIconScale());
-
-    DrawLightGreenTri(mtx);
+    DrawColoredTri(HudmapIconColors[iconType], mtx);
 }
 
 void mmHudMapFeatureHandler::DrawPlayer() {
@@ -2214,154 +2163,253 @@ void mmHudMapFeatureHandler::DrawPlayer() {
     auto audio = car->getAudio();
     auto siren = car->getSiren();
     char *vehName = car->getCarDamage()->GetName();
-    bool elapsedTime1 = fmod(datTimeManager::ElapsedTime, 0.15f) > 0.1f;
-    bool elapsedTime2 = fmod(datTimeManager::ElapsedTime, 0.125f) > 0.1f;
-    bool elapsedTime3 = fmod(datTimeManager::ElapsedTime, 0.5f) > 0.25f;
+    bool flashFrequency1 = fmod(datTimeManager::ElapsedTime, 0.09375f) > 0.03125f;
+    bool flashFrequency2 = fmod(datTimeManager::ElapsedTime, 0.09375f) > 0.0625f;
+    bool flashFrequency3 = fmod(datTimeManager::ElapsedTime, 0.5f) > 0.25f;
 
     // draw triangle outline
     auto playerMtx = hudmap->GetPlayerMatrix();
     float scaleAmount = hudmap->GetIconScale() * 1.3f;
     float iconScale = hudmap->GetIconScale();
-    hudmap->SetIconScale(scaleAmount);
 
-    if (hudMapColorStyle == 0) {
-        DrawIcon(0, *playerMtx);
+    if (MMSTATE->Multiplayer && MMSTATE->CnRMode)
+    {
+        hudmap->SetIconScale(scaleAmount);
+        DrawIcon(Black, *playerMtx);
         hudmap->SetIconScale(iconScale);
-        DrawIcon(5, *playerMtx);
+
+        if (cfgBlacknWhiteCnRTeams.Get())
+        {
+            if (MMSTATE->CnRTeam)
+            {
+                DrawIcon(Black, *playerMtx);
+            }
+            else {
+                DrawIcon(White, *playerMtx);
+            }
+        }
+        else {
+            if (MMSTATE->CnRTeam)
+            {
+                DrawIcon(Red, *playerMtx);
+            }
+            else {
+                DrawIcon(Blue, *playerMtx);
+            }
+        }
     }
-    if (hudMapColorStyle == 1) {
-        if (audio->IsPolice(vehName)) {
-            DrawIcon(2, *playerMtx);
+    else {
+        // MM2
+        if (hudMapColorStyle == 0)
+        {
+            hudmap->SetIconScale(scaleAmount);
+            DrawIcon(Black, *playerMtx);
             hudmap->SetIconScale(iconScale);
-            DrawIcon(1, *playerMtx);
+            DrawIcon(Yellow, *playerMtx);
         }
-        else {
-            DrawIcon(-1, *playerMtx);
+        // MM1
+        if (hudMapColorStyle == 1)
+        {
+            if (audio->IsPolice(vehName))
+            {
+                hudmap->SetIconScale(scaleAmount);
+                DrawIcon(Blue, *playerMtx);
+                hudmap->SetIconScale(iconScale);
+                DrawIcon(BrightRed, *playerMtx);
+            }
+            else {
+                if (hudmap->GetMapMode() == HalfScreen)
+                {
+                    hudmap->SetIconScale(iconScale * 1.34f);
+                }
+                else {
+                    hudmap->SetIconScale(iconScale * 1.37f);
+                }
+                DrawIcon(Black, *playerMtx);
+                hudmap->SetIconScale(scaleAmount);
+                DrawIcon(White, *playerMtx);
+                hudmap->SetIconScale(iconScale);
+                DrawIcon(Black, *playerMtx);
+            }
+        }
+        // NFSHP2
+        if (hudMapColorStyle == 2)
+        {
+            hudmap->SetIconScale(scaleAmount);
+            DrawIcon(Black, *playerMtx);
             hudmap->SetIconScale(iconScale);
-            DrawIcon(0, *playerMtx);
-        }
-    }
-    if (hudMapColorStyle == 2) {
-        DrawIcon(0, *playerMtx);
-        hudmap->SetIconScale(iconScale);
-        if (audio->IsPolice(vehName)) {
-            DrawIcon(2, *playerMtx);
-            if (siren != nullptr && siren->getActive()) {
-                if (elapsedTime3)
-                    DrawIcon(1, *playerMtx);
+
+            if (audio->IsPolice(vehName))
+            {
+                DrawIcon(Blue, *playerMtx);
+
+                if (siren != nullptr && siren->getActive())
+                {
+                    if (flashFrequency3)
+                        DrawIcon(BrightRed, *playerMtx);
+                }
+            }
+            else {
+                DrawIcon(Yellow, *playerMtx);
             }
         }
-        else {
-            DrawIcon(5, *playerMtx);
-        }
-    }
-    if (hudMapColorStyle == 3) {
-        DrawIcon(0, *playerMtx);
-        hudmap->SetIconScale(iconScale);
-        if (audio->IsPolice(vehName)) {
-            if (siren != nullptr && siren->getActive()) {
-                DrawIcon(2, *playerMtx);
-                if (elapsedTime1)
-                    DrawIcon(1, *playerMtx);
-                if (elapsedTime2)
-                    DrawIcon(-1, *playerMtx);
+        // NFSMW
+        if (hudMapColorStyle == 3)
+        {
+            hudmap->SetIconScale(scaleAmount);
+            DrawIcon(Black, *playerMtx);
+            hudmap->SetIconScale(iconScale);
+
+            if (audio->IsPolice(vehName))
+            {
+                DrawIcon(White, *playerMtx);
+
+                if (siren != nullptr && siren->getActive())
+                {
+                    if (flashFrequency1)
+                        DrawIcon(Blue, *playerMtx);
+
+                    if (flashFrequency2)
+                        DrawIcon(BrightRed, *playerMtx);
+                }
             }
-            if (siren != nullptr && !siren->getActive()) {
-                DrawIcon(-1, *playerMtx);
-            }
-        }
-        else {
-            DrawNfsMwPlayerIcon(*playerMtx);
-        }
-    }
-    if (hudMapColorStyle == 4) {
-        DrawIcon(0, *playerMtx);
-        hudmap->SetIconScale(iconScale);
-        if (audio->IsPolice(vehName)) {
-            if (siren != nullptr && siren->getActive()) {
-                DrawIcon(2, *playerMtx);
-                if (elapsedTime1)
-                    DrawIcon(1, *playerMtx);
-                if (elapsedTime2)
-                    DrawIcon(-1, *playerMtx);
-            }
-            if (siren != nullptr && !siren->getActive()) {
-                DrawIcon(4, *playerMtx);
+            else {
+                DrawIcon(LightOrange, *playerMtx);
             }
         }
-        else {
-            DrawIcon(8, *playerMtx);
+        // NFSC
+        if (hudMapColorStyle == 4)
+        {
+            hudmap->SetIconScale(scaleAmount);
+            DrawIcon(Black, *playerMtx);
+            hudmap->SetIconScale(iconScale);
+
+            if (audio->IsPolice(vehName))
+            {
+                DrawIcon(Red, *playerMtx);
+
+                if (siren != nullptr && siren->getActive())
+                {
+                    if (flashFrequency1)
+                        DrawIcon(Blue, *playerMtx);
+
+                    if (flashFrequency2)
+                        DrawIcon(White, *playerMtx);
+                }
+            }
+            else {
+                DrawIcon(Cyan, *playerMtx);
+            }
         }
-    }
-    if (hudMapColorStyle >= 5) {
-        DrawIcon(playerTriOutlineColor, *playerMtx);
-        hudmap->SetIconScale(iconScale);
-        DrawIcon(playerTriColor, *playerMtx);
+        // Custom
+        if (hudMapColorStyle >= 5)
+        {
+            hudmap->SetIconScale(scaleAmount);
+            DrawIcon(playerTriOutlineColor, *playerMtx);
+            hudmap->SetIconScale(iconScale);
+            DrawIcon(playerTriColor, *playerMtx);
+        }
     }
 }
 
 void mmHudMapFeatureHandler::DrawCops() {
     auto hudmap = reinterpret_cast<mmHudMap*>(this);
     auto AIMAP = &aiMap::Instance;
-    bool elapsedTime1 = fmod(datTimeManager::ElapsedTime, 0.15f) > 0.1f;
-    bool elapsedTime2 = fmod(datTimeManager::ElapsedTime, 0.125f) > 0.1f;
-    bool elapsedTime3 = fmod(datTimeManager::ElapsedTime, 0.5f) > 0.25f;
-    BOOL ShowAllCops = hudmap->GetShowAllCops();
+    bool flashFrequency1 = fmod(datTimeManager::ElapsedTime, 0.09375f) > 0.03125f;
+    bool flashFrequency2 = fmod(datTimeManager::ElapsedTime, 0.09375f) > 0.0625f;
+    bool flashFrequency3 = fmod(datTimeManager::ElapsedTime, 0.5f) > 0.25f;
 
-    for (int i = 0; i < AIMAP->numCops; i++) {
+    for (int i = 0; i < AIMAP->numCops; i++)
+    {
         auto police = AIMAP->Police(i);
         auto policeMtx = police->getCar()->getCarSim()->getICS()->GetMatrix();
-        short policeState = police->getPoliceState();
 
-        // check if the cop in pursuit
-        if (policeState || ShowAllCops) {
+        if (police->InPersuit() || hudmap->GetShowAllCops())
+        {
             // draw triangle outline
             float scaleAmount = hudmap->GetIconScale() * 1.3f;
             float iconScale = hudmap->GetIconScale();
-            hudmap->SetIconScale(scaleAmount);
 
-            if (hudMapColorStyle == 0) {
-                DrawIcon(0, *policeMtx);
+            // MM2
+            if (hudMapColorStyle == 0)
+            {
+                hudmap->SetIconScale(scaleAmount);
+                DrawIcon(Black, *policeMtx);
                 hudmap->SetIconScale(iconScale);
-                DrawIcon(1, *policeMtx);
+
+                if (police->Destroyed())
+                    DrawIcon(DarkRed, *policeMtx);
+                else
+                    DrawIcon(BrightRed, *policeMtx);
             }
-            if (hudMapColorStyle == 1) {
-                DrawIcon(2, *policeMtx);
+            // MM1
+            if (hudMapColorStyle == 1)
+            {
+                hudmap->SetIconScale(scaleAmount);
+
+                if (police->Destroyed()) {
+                    DrawIcon(DarkBlue, *policeMtx);
+                    hudmap->SetIconScale(iconScale);
+                    DrawIcon(DarkRed, *policeMtx);
+                }
+                else {
+                    DrawIcon(Blue, *policeMtx);
+                    hudmap->SetIconScale(iconScale);
+                    DrawIcon(BrightRed, *policeMtx);
+                }
+            }
+            // NFSHP2
+            if (hudMapColorStyle == 2)
+            {
+                hudmap->SetIconScale(scaleAmount);
+                DrawIcon(Black, *policeMtx);
                 hudmap->SetIconScale(iconScale);
-                DrawIcon(1, *policeMtx);
+                DrawIcon(Blue, *policeMtx);
+
+                if (police->InPersuit() && !police->Destroyed())
+                {
+                    if (flashFrequency3)
+                        DrawIcon(BrightRed, *policeMtx);
+                }
             }
-            if (hudMapColorStyle == 2) {
-                DrawIcon(0, *policeMtx);
+            // NFSMW
+            if (hudMapColorStyle == 3)
+            {
+                hudmap->SetIconScale(scaleAmount);
+                DrawIcon(Black, *policeMtx);
                 hudmap->SetIconScale(iconScale);
-                DrawIcon(2, *policeMtx);
-                if (elapsedTime3)
-                    DrawIcon(1, *policeMtx);
-                if (policeState == 12 || policeState == 0)
-                    DrawIcon(2, *policeMtx);
+                DrawIcon(White, *policeMtx);
+
+                if (police->InPersuit() && !police->Destroyed())
+                {
+                    if (flashFrequency1)
+                        DrawIcon(Blue, *policeMtx);
+
+                    if (flashFrequency2)
+                        DrawIcon(BrightRed, *policeMtx);
+                }
             }
-            if (hudMapColorStyle == 3) {
-                DrawIcon(0, *policeMtx);
+            // NFSC
+            if (hudMapColorStyle == 4)
+            {
+                hudmap->SetIconScale(scaleAmount);
+                DrawIcon(Black, *policeMtx);
                 hudmap->SetIconScale(iconScale);
-                DrawIcon(2, *policeMtx);
-                if (elapsedTime1)
-                    DrawIcon(1, *policeMtx);
-                if (elapsedTime2)
-                    DrawIcon(-1, *policeMtx);
-                if (policeState == 12 || policeState == 0)
-                    DrawIcon(-1, *policeMtx);
+                DrawIcon(Red, *policeMtx);
+
+                if (police->InPersuit() && !police->Destroyed())
+                {
+                    if (flashFrequency1)
+                        DrawIcon(Blue, *policeMtx);
+
+                    if (flashFrequency2)
+                        DrawIcon(White, *policeMtx);
+                }
             }
-            if (hudMapColorStyle == 4) {
-                DrawIcon(0, *policeMtx);
-                hudmap->SetIconScale(iconScale);
-                DrawIcon(2, *policeMtx);
-                if (elapsedTime1)
-                    DrawIcon(1, *policeMtx);
-                if (elapsedTime2)
-                    DrawIcon(-1, *policeMtx);
-                if (policeState == 12 || policeState == 0)
-                    DrawIcon(4, *policeMtx);
-            }
-            if (hudMapColorStyle >= 5) {
+            // Custom
+            if (hudMapColorStyle >= 5)
+            {
+                hudmap->SetIconScale(scaleAmount);
                 DrawIcon(policeTriOutlineColor, *policeMtx);
                 hudmap->SetIconScale(iconScale);
                 DrawIcon(policeTriColor, *policeMtx);
@@ -2374,64 +2422,122 @@ void mmHudMapFeatureHandler::DrawOpponents() {
     auto hudmap = reinterpret_cast<mmHudMap*>(this);
     auto AIMAP = &aiMap::Instance;
 
-    for (int i = 0; i < hudmap->GetNumOpponents(); i++) {
+    for (int i = 0; i < hudmap->GetNumOpponents(); i++)
+    {
         auto oppIconInfo = hudmap->GetOppIconInfo(i);
         auto opponentMtx = oppIconInfo->Matrix;
 
-        if (oppIconInfo->Enabled && opponentMtx) {
+        if (oppIconInfo->Enabled && opponentMtx)
+        {
             // draw triangle outline
             float scaleAmount = hudmap->GetIconScale() * 1.3f;
             float iconScale = hudmap->GetIconScale();
-            hudmap->SetIconScale(scaleAmount);
 
-            // check if we're in multiplayer
-            if (MMSTATE->unk_EC) {
-                DrawIcon(0, *opponentMtx);
+            if (MMSTATE->Multiplayer)
+            {
+                hudmap->SetIconScale(scaleAmount);
+                DrawIcon(Black, *opponentMtx);
                 hudmap->SetIconScale(iconScale);
-                DrawIcon(i + 2, *opponentMtx);
-            } 
+
+                if (oppIconInfo->Color == 0xFF0000EF)
+                {   
+                    DrawIcon(Blue, *opponentMtx);
+                }
+                if (oppIconInfo->Color == 0xFF00EF00)
+                {
+                    DrawIcon(Green, *opponentMtx);
+                }
+                if (oppIconInfo->Color == 0xFFEF0000)
+                {
+                    DrawIcon(Red, *opponentMtx);
+                }
+                if (oppIconInfo->Color == 0xFFFFFF00)
+                {
+                    DrawIcon(Yellow, *opponentMtx);
+                }
+                if (oppIconInfo->Color == 0xFFFF5A00)
+                {
+                    DrawIcon(Orange, *opponentMtx);
+                }
+                if (oppIconInfo->Color == 0xFFB400FF)
+                {
+                    DrawIcon(Purple, *opponentMtx);
+                }
+                if (oppIconInfo->Color == 0xFF00FFFF)
+                {
+                    DrawIcon(Cyan, *opponentMtx);
+                }
+                if (oppIconInfo->Color == 0xFFFF0390)
+                {
+                    DrawIcon(Pink, *opponentMtx);
+                }
+                if (oppIconInfo->Color == 0xFFFFFFFF)
+                {
+                    DrawIcon(White, *opponentMtx);
+                }
+            }
             else {
                 auto opponent = AIMAP->Opponent(i);
                 auto car = opponent->getCar();
                 auto curDamage = car->getCarDamage()->getCurDamage();
                 auto maxDamage = car->getCarDamage()->getMaxDamage();
 
-                if (curDamage <= maxDamage) {
-                    if (hudMapColorStyle == 0) {
-                        DrawIcon(0, *opponentMtx);
+                if (curDamage <= maxDamage)
+                {
+                    // MM2
+                    if (hudMapColorStyle == 0)
+                    {
+                        hudmap->SetIconScale(scaleAmount);
+                        DrawIcon(Black, *opponentMtx);
                         hudmap->SetIconScale(iconScale);
-                        DrawIcon(7, *opponentMtx);
+                        DrawIcon(Purple, *opponentMtx);
                     }
-                    if (hudMapColorStyle == 1) {
-                        DrawIcon(0, *opponentMtx);
+                    // MM1
+                    if (hudMapColorStyle == 1)
+                    {
+                        hudmap->SetIconScale(scaleAmount);
+                        DrawIcon(Black, *opponentMtx);
                         hudmap->SetIconScale(iconScale);
                         DrawIcon(i + 2, *opponentMtx);
                     }
-                    if (hudMapColorStyle == 2) {
-                        DrawIcon(0, *opponentMtx);
+                    // NFSHP2
+                    if (hudMapColorStyle == 2)
+                    {
+                        hudmap->SetIconScale(scaleAmount);
+                        DrawIcon(Black, *opponentMtx);
                         hudmap->SetIconScale(iconScale);
-                        DrawIcon(3, *opponentMtx);
+                        DrawIcon(Green, *opponentMtx);
                     }
-                    if (hudMapColorStyle == 3) {
-                        DrawIcon(0, *opponentMtx);
+                    // NFSMW
+                    if (hudMapColorStyle == 3)
+                    {
+                        hudmap->SetIconScale(scaleAmount);
+                        DrawIcon(Black, *opponentMtx);
                         hudmap->SetIconScale(iconScale);
-                        DrawNfsMwOpponentIcon(*opponentMtx);
+                        DrawIcon(LightGreen, *opponentMtx);
                     }
-                    if (hudMapColorStyle == 4) {
-                        DrawIcon(0, *opponentMtx);
+                    // NFSC
+                    if (hudMapColorStyle == 4)
+                    {
+                        hudmap->SetIconScale(scaleAmount);
+                        DrawIcon(Black, *opponentMtx);
                         hudmap->SetIconScale(iconScale);
-                        DrawIcon(6, *opponentMtx);
+                        DrawIcon(Orange, *opponentMtx);
                     }
-                    if (hudMapColorStyle >= 5) {
+                    // Custom
+                    if (hudMapColorStyle >= 5)
+                    {
+                        hudmap->SetIconScale(scaleAmount);
                         DrawIcon(opponentTriOutlineColor, *opponentMtx);
                         hudmap->SetIconScale(iconScale);
                         DrawIcon(opponentTriColor, *opponentMtx);
                     }
                 }
                 else {
-                    DrawIcon(0, *opponentMtx);
+                    hudmap->SetIconScale(scaleAmount);
+                    DrawIcon(Black, *opponentMtx);
                     hudmap->SetIconScale(iconScale);
-                    DrawIcon(16, *opponentMtx);
+                    DrawIcon(Grey, *opponentMtx);
                 }
             }
         }
@@ -2483,101 +2589,118 @@ static ConfigValue<int> cfgOpponentIconStyle           ("OpponentIconStyle",    
 static ConfigValue<int> cfgOpponentIconColor           ("OpponentIconColor",           5);
 static ConfigValue<int> cfgBlitzIconColor              ("BlitzIconColor",              6);
 
-unsigned int IconColors[8] = {
+unsigned int IconColors[11] = {
     0xFF0000EF, // Blue
     0xFF00EF00, // Green
     0xFFEF0000, // Red
     0xFFFFFF00, // Yellow
     0xFFFF5A00, // Orange
     0xFFB400FF, // Purple
-    0xFF00FFFF, // Aqua
+    0xFF00FFFF, // Cyan
     0xFFFF0390, // Pink
+
+    // Custom Colors
+    0xFFFFFFFF, // White
+    0xFF000000, // Black
+    0xFFC0EC42, // Light Green
 };
 
-unsigned int SemiTransIconColors[8] = {
+unsigned int SemiTransIconColors[11] = {
     0x800000EF, // Blue
     0x8000EF00, // Green
     0x80EF0000, // Red
     0x80FFFF00, // Yellow
     0x80FF5A00, // Orange
     0x80B400FF, // Purple
-    0x8000FFFF, // Aqua
+    0x8000FFFF, // Cyan
     0x80FF0390, // Pink
+
+    // Custom Colors
+    0x80FFFFFF, // White
+    0x80000000, // Black
+    0x80C0EC42, // Light Green
 };
 
-void mmIconsHandler::RegisterOpponents(OppIconInfo *icons, int count, void *a3) {
+void mmIconsFeatureHandler::RegisterOpponents(OppIconInfo *icon, int count, void *font) {
+    auto icons = reinterpret_cast<mmIcons*>(this);
+
     for (int i = 0; i < count; i++) {
         if (opponentIconTransparency) {
             if (opponentIconStyle == 0) {
-                icons[i].Color = SemiTransIconColors[5];
+                icon[i].Color = SemiTransIconColors[5];
             }
             if (opponentIconStyle == 1) {
-                icons[i].Color = SemiTransIconColors[i];
+                icon[i].Color = SemiTransIconColors[i];
             }
             if (opponentIconStyle == 2) {
-                icons[i].Color = SemiTransIconColors[1];
+                icon[i].Color = SemiTransIconColors[1];
             }
             if (opponentIconStyle == 3) {
-                icons[i].Color = 0x80C0EC42; // semi-transparent Light Green
+                icon[i].Color = SemiTransIconColors[10];
             }
             if (opponentIconStyle == 4) {
-                icons[i].Color = SemiTransIconColors[4];
+                icon[i].Color = SemiTransIconColors[4];
             }
             if (opponentIconStyle >= 5) {
-                icons[i].Color = SemiTransIconColors[opponentIconColor];
+                icon[i].Color = SemiTransIconColors[opponentIconColor];
             }
         }
         else {
             if (opponentIconStyle == 0) {
-                icons[i].Color = IconColors[5];
+                icon[i].Color = IconColors[5];
             }
             if (opponentIconStyle == 1) {
-                icons[i].Color = IconColors[i];
+                icon[i].Color = IconColors[i];
             }
             if (opponentIconStyle == 2) {
-                icons[i].Color = IconColors[1];
+                icon[i].Color = IconColors[1];
             }
             if (opponentIconStyle == 3) {
-                icons[i].Color = 0xFFC0EC42; // Light Green
+                icon[i].Color = IconColors[10];
             }
             if (opponentIconStyle == 4) {
-                icons[i].Color = IconColors[4];
+                icon[i].Color = IconColors[4];
             }
             if (opponentIconStyle >= 5) {
-                icons[i].Color = IconColors[opponentIconColor];
+                icon[i].Color = IconColors[opponentIconColor];
             }
         }
     }
 
-    //call original
-    hook::Thunk<0x4322F0>::Call<void>(this, icons, count, a3);
+    icons->RegisterOpponents(icon, count, font);
 }
 
-void mmIconsHandler::RegisterOpponentsBlitz(OppIconInfo *icons, int count, void *a3) {
+void mmIconsFeatureHandler::RegisterOpponentsBlitz(OppIconInfo *icon, int count, void *font) {
+    auto icons = reinterpret_cast<mmIcons*>(this);
+
     for (int i = 0; i < count; i++) {
         if (blitzIconTransparency) {
             if (blitzIconMultiColor) {
-                icons[i].Color = SemiTransIconColors[i];
+                icon[i].Color = SemiTransIconColors[i];
             }
             if (!blitzIconMultiColor) {
-                icons[i].Color = SemiTransIconColors[blitzIconColor];
+                icon[i].Color = SemiTransIconColors[blitzIconColor];
             }
         }
         if (!blitzIconTransparency) {
             if (blitzIconMultiColor) {
-                icons[i].Color = IconColors[i];
+                icon[i].Color = IconColors[i];
             }
             if (!blitzIconMultiColor) {
-                icons[i].Color = IconColors[blitzIconColor];
+                icon[i].Color = IconColors[blitzIconColor];
             }
         }
     }
 
-    //call original
-    hook::Thunk<0x4322F0>::Call<void>(this, icons, count, a3);
+    icons->RegisterOpponents(icon, count, font);
 }
 
-void mmIconsHandler::Install() {
+void mmIconsFeatureHandler::RegisterOpponentsMulti(OppIconInfo* icon, int count, void *font) {
+    auto icons = reinterpret_cast<mmIcons*>(this);
+    icons->RegisterOpponents(icon, count, font);
+}
+
+void mmIconsFeatureHandler::Install() {
     opponentIconStyle = cfgOpponentIconStyle.Get();
     opponentIconColor = cfgOpponentIconColor.Get();
     opponentIconTransparency = cfgOpponentIconTransparency.Get();
@@ -2596,6 +2719,239 @@ void mmIconsHandler::Install() {
             cb::call(0x41B065), // mmSingleBlitz::Init
         }
     );
+
+    InstallCallback("mmIcons::RegisterOpponents [mmGameMulti]",
+        &RegisterOpponentsMulti, {
+            cb::call(0x43AED3), // mmGameMulti::RegisterMapNetObjects
+        }
+    );
+    
+    // move down place icon position (X Matrix)
+    InstallPatch({ 0x78, 0x5, 0x5B, 0x0 }, {
+       0x4326B6 + 2, // mmIcons::Cull
+    });
+
+    // move down place icon position (Y Matrix)
+    InstallPatch({ 0x78, 0x5, 0x5B, 0x0 }, {
+       0x432746 + 2, // mmIcons::Cull
+    });
+
+    // move down place icon position (Z Matrix)
+    InstallPatch({ 0x78, 0x5, 0x5B, 0x0 }, {
+       0x4327D6 + 2, // mmIcons::Cull
+    });
+
+    // move down place icon position (W Matrix)
+    InstallPatch({ 0x78, 0x5, 0x5B, 0x0 }, {
+       0x432865 + 2, // mmIcons::Cull
+    });
+
+    /*
+        Set gold icon value to 10
+    */
+
+    // Opp Icon Gold
+    InstallPatch({ 10 }, {
+       0x42559E + 6, // mmMultiCR::OppStealGold
+    });
+
+    // Opp Icon Blank
+    InstallPatch({ 11 }, {
+       0x432622 + 4, // mmIcons::Cull
+    });
+
+    // Opp Icon Blank
+    InstallPatch({ 11 }, {
+       0x4267E5 + 6, // mmMultiCR::GameMessage
+    });
+
+    // Opp Icon Blank
+    InstallPatch({ 11 }, {
+       0x426908 + 7, // mmMultiCR::GameMessage
+    });
+
+    // Opp Icon Blank
+    InstallPatch({ 11 }, {
+       0x43AE69 + 3, // mmGameMulti::RegisterMapNetObjects
+    });
+
+    // Opp Icon Blank
+    InstallPatch({ 11 }, {
+       0x43AF11 + 6, // mmGameMulti::DeactivateMapNetObject
+    });
+
+    if (!cfgBlacknWhiteCnRTeams.Get())
+        return;
+
+    /*
+        mmMultiCR::InitNetworkPlayers
+    */
+
+    // Black
+    InstallPatch({ 0x20, 0x20, 0x20, 0xFF }, {
+       0x42433D + 3,
+    });
+
+    // White
+    InstallPatch({ 0xFF, 0xFF, 0xFF, 0xFF }, {
+       0x424358 + 3,
+    });
+
+    /*
+        mmMultiCR::GameMessage
+    */
+
+    // Black
+    InstallPatch({ 0x20, 0x20, 0x20, 0xFF }, {
+       0x4269AF + 7,
+    });
+
+    // White
+    InstallPatch({ 0xFF, 0xFF, 0xFF, 0xFF }, {
+       0x4269D6 + 7,
+    });
+
+    // Black
+    InstallPatch({ 0x0, 0x0, 0x0, 0xFF }, {
+       0x426BDA + 7,
+    });
+
+    // White
+    InstallPatch({ 0xFF, 0xFF, 0xFF, 0xFF }, {
+       0x426C01 + 7,
+    });
+
+    /*
+        mmCRHUD::SetName
+    */
+
+    // Black
+    InstallPatch({ 0x0, 0x3E }, {
+       0x437F81 + 5,
+    });
+
+    // Black
+    InstallPatch({ 0x3E }, {
+       0x437F8B + 6,
+    });
+
+    // Black
+    InstallPatch({ 0x3E }, {
+       0x437F92 + 6,
+    });
+
+    // White
+    InstallPatch({ 0x80, 0x3F }, {
+       0x437FB2 + 5,
+    });
+
+    // White
+    InstallPatch({ 0x80, 0x3F }, {
+       0x437FB9 + 5,
+    });
+}
+
+/*
+    mmTextNodeHandler
+*/
+
+void mmTextNodeHandler::GetTextDimensionsWhite(void const* a1, char const* a2, float& a3, float& a4)
+{
+    auto textNode = reinterpret_cast<mmTextNode*>(this);
+
+    if (MMSTATE->CnRMode == 2)
+        a2 = "WHITE";
+
+    textNode->GetTextDimensions(a1, a2, a3, a4);
+}
+
+void mmTextNodeHandler::GetTextDimensionsBlack(void const* a1, char const* a2, float& a3, float& a4)
+{
+    auto textNode = reinterpret_cast<mmTextNode*>(this);
+
+    if (MMSTATE->CnRMode == 2)
+        a2 = "BLACK";
+
+    textNode->GetTextDimensions(a1, a2, a3, a4);
+}
+
+void mmTextNodeHandler::AddTextWhite(void const* a1, char const* a2, int a3, float a4, float a5)
+{
+    auto textNode = reinterpret_cast<mmTextNode*>(this);
+
+    if (MMSTATE->CnRMode == 2)
+        a2 = "WHITE";
+
+    textNode->AddText(a1, a2, a3, a4, a5);
+}
+
+void mmTextNodeHandler::AddTextBlack(void const* a1, char const* a2, int a3, float a4, float a5)
+{
+    auto textNode = reinterpret_cast<mmTextNode*>(this);
+
+    if (MMSTATE->CnRMode == 2)
+        a2 = "BLACK";
+
+    textNode->AddText(a1, a2, a3, a4, a5);
+}
+
+void mmTextNodeHandler::Install()
+{
+    if (!cfgBlacknWhiteCnRTeams.Get())
+        return;
+
+    InstallCallback("mmTextNode::GetTextDimensions[White]", "Replaces Blue text dimension with White.",
+        &GetTextDimensionsWhite, {
+            cb::call(0x4377F1),
+        }
+    );
+
+    InstallCallback("mmTextNode::GetTextDimensions[Black]", "Replaces Red text dimension with Black.",
+        &GetTextDimensionsBlack, {
+            cb::call(0x43783D),
+        }
+    );
+
+    InstallCallback("mmTextNode::AddText[White]", "Replaces Blue text with White.",
+        &AddTextWhite, {
+            cb::call(0x437885),
+        }
+    );
+
+    InstallCallback("mmTextNode::AddText[Black]", "Replaces Red text with Black.",
+        &AddTextBlack, {
+            cb::call(0x43789E),
+        }
+    );
+
+    /*
+        mmCRHUD::Init
+    */
+
+    // White
+    InstallPatch({ 0x80, 0x3F }, {
+       0x4378C3 + 5,
+    });
+
+    // White
+    InstallPatch({ 0x80, 0x3F }, {
+       0x4378CA + 5,
+    });
+
+    // Black
+    InstallPatch({ 0x0, 0x3E }, {
+       0x4378F8 + 5,
+    });
+
+    // Black
+    InstallPatch({ 0x3E }, {
+       0x4378FF + 6,
+    });
+
+    // Black
+    InstallPatch({ 0x3E }, {
+       0x437906 + 6,
+    });
 }
 
 /*
@@ -5024,7 +5380,7 @@ void vehBreakableMgrHandler::Install() {
 const char* vehCarModelFeatureHandler::VehNameRemap(const char* basename) {
     char* playerName = MMCURRPLAYER->GetName();
 
-    if (MMSTATE->GameMode == Cruise && !MMSTATE->unk_EC)
+    if (MMSTATE->GameMode == Cruise && !MMSTATE->Multiplayer)
     {
         if (!strcmp(playerName, "va2siter") && !strcmp(basename, "vpdb7"))
             return "va_2siter_s";

--- a/src/handlers/feature_handlers.cpp
+++ b/src/handlers/feature_handlers.cpp
@@ -2747,6 +2747,20 @@ void mmIconsFeatureHandler::Install() {
     });
 
     /*
+        Fix last place icon rendering
+    */
+
+    // Cull loop
+    InstallPatch({ 0x8C }, {
+       0x432422 + 1, // mmIcons::Cull
+    });
+    
+    // Cull loop
+    InstallPatch({ 0x8E }, {
+       0x4328E2 + 1, // mmIcons::Cull
+    });
+
+    /*
         Set gold icon value to 10
     */
 

--- a/src/handlers/feature_handlers.cpp
+++ b/src/handlers/feature_handlers.cpp
@@ -2141,7 +2141,7 @@ void mmHudMapFeatureHandler::DrawColoredTri(unsigned int color, const Matrix34 &
     rglEnableDisable(RGL_DEPTH_TEST, true);
 }
 
-void mmHudMapFeatureHandler::DrawIcon(int iconType, const Matrix34& matrix) {
+void mmHudMapFeatureHandler::DrawIcon(int iconColor, const Matrix34& matrix) {
     auto hudmap = reinterpret_cast<mmHudMap*>(this);
 
     Matrix34 mtx;
@@ -2153,7 +2153,7 @@ void mmHudMapFeatureHandler::DrawIcon(int iconType, const Matrix34& matrix) {
     mtx.m31 += 15.f;
     mtx.Scale(hudmap->GetIconScale());
 
-    DrawColoredTri(HudmapIconColors[iconType], mtx);
+    DrawColoredTri(HudmapIconColors[iconColor], mtx);
 }
 
 void mmHudMapFeatureHandler::DrawPlayer() {
@@ -2175,26 +2175,26 @@ void mmHudMapFeatureHandler::DrawPlayer() {
     if (MMSTATE->Multiplayer && MMSTATE->CnRMode)
     {
         hudmap->SetIconScale(scaleAmount);
-        DrawIcon(Black, *playerMtx);
+        DrawIcon(mmHudMap::Black, *playerMtx);
         hudmap->SetIconScale(iconScale);
 
         if (cfgBlacknWhiteCnRTeams.Get())
         {
             if (MMSTATE->CnRTeam)
             {
-                DrawIcon(Black, *playerMtx);
+                DrawIcon(mmHudMap::Black, *playerMtx);
             }
             else {
-                DrawIcon(White, *playerMtx);
+                DrawIcon(mmHudMap::White, *playerMtx);
             }
         }
         else {
             if (MMSTATE->CnRTeam)
             {
-                DrawIcon(Red, *playerMtx);
+                DrawIcon(mmHudMap::Red, *playerMtx);
             }
             else {
-                DrawIcon(Blue, *playerMtx);
+                DrawIcon(mmHudMap::Blue, *playerMtx);
             }
         }
     }
@@ -2203,9 +2203,9 @@ void mmHudMapFeatureHandler::DrawPlayer() {
         if (hudMapColorStyle == 0)
         {
             hudmap->SetIconScale(scaleAmount);
-            DrawIcon(Black, *playerMtx);
+            DrawIcon(mmHudMap::Black, *playerMtx);
             hudmap->SetIconScale(iconScale);
-            DrawIcon(Yellow, *playerMtx);
+            DrawIcon(mmHudMap::Yellow, *playerMtx);
         }
         // MM1
         if (hudMapColorStyle == 1)
@@ -2213,92 +2213,92 @@ void mmHudMapFeatureHandler::DrawPlayer() {
             if (audio->IsPolice(vehName))
             {
                 hudmap->SetIconScale(scaleAmount);
-                DrawIcon(Blue, *playerMtx);
+                DrawIcon(mmHudMap::Blue, *playerMtx);
                 hudmap->SetIconScale(iconScale);
-                DrawIcon(BrightRed, *playerMtx);
+                DrawIcon(mmHudMap::BrightRed, *playerMtx);
             }
             else {
-                if (hudmap->GetMapMode() == HalfScreen)
+                if (hudmap->GetMapMode() == mmHudMap::HalfScreen)
                 {
                     hudmap->SetIconScale(iconScale * 1.34f);
                 }
                 else {
                     hudmap->SetIconScale(iconScale * 1.37f);
                 }
-                DrawIcon(Black, *playerMtx);
+                DrawIcon(mmHudMap::Black, *playerMtx);
                 hudmap->SetIconScale(scaleAmount);
-                DrawIcon(White, *playerMtx);
+                DrawIcon(mmHudMap::White, *playerMtx);
                 hudmap->SetIconScale(iconScale);
-                DrawIcon(Black, *playerMtx);
+                DrawIcon(mmHudMap::Black, *playerMtx);
             }
         }
         // NFSHP2
         if (hudMapColorStyle == 2)
         {
             hudmap->SetIconScale(scaleAmount);
-            DrawIcon(Black, *playerMtx);
+            DrawIcon(mmHudMap::Black, *playerMtx);
             hudmap->SetIconScale(iconScale);
 
             if (audio->IsPolice(vehName))
             {
-                DrawIcon(Blue, *playerMtx);
+                DrawIcon(mmHudMap::Blue, *playerMtx);
 
                 if (siren != nullptr && siren->getActive())
                 {
                     if (flashFrequency3)
-                        DrawIcon(BrightRed, *playerMtx);
+                        DrawIcon(mmHudMap::BrightRed, *playerMtx);
                 }
             }
             else {
-                DrawIcon(Yellow, *playerMtx);
+                DrawIcon(mmHudMap::Yellow, *playerMtx);
             }
         }
         // NFSMW
         if (hudMapColorStyle == 3)
         {
             hudmap->SetIconScale(scaleAmount);
-            DrawIcon(Black, *playerMtx);
+            DrawIcon(mmHudMap::Black, *playerMtx);
             hudmap->SetIconScale(iconScale);
 
             if (audio->IsPolice(vehName))
             {
-                DrawIcon(White, *playerMtx);
+                DrawIcon(mmHudMap::White, *playerMtx);
 
                 if (siren != nullptr && siren->getActive())
                 {
                     if (flashFrequency1)
-                        DrawIcon(Blue, *playerMtx);
+                        DrawIcon(mmHudMap::Blue, *playerMtx);
 
                     if (flashFrequency2)
-                        DrawIcon(BrightRed, *playerMtx);
+                        DrawIcon(mmHudMap::BrightRed, *playerMtx);
                 }
             }
             else {
-                DrawIcon(LightOrange, *playerMtx);
+                DrawIcon(mmHudMap::LightOrange, *playerMtx);
             }
         }
         // NFSC
         if (hudMapColorStyle == 4)
         {
             hudmap->SetIconScale(scaleAmount);
-            DrawIcon(Black, *playerMtx);
+            DrawIcon(mmHudMap::Black, *playerMtx);
             hudmap->SetIconScale(iconScale);
 
             if (audio->IsPolice(vehName))
             {
-                DrawIcon(Red, *playerMtx);
+                DrawIcon(mmHudMap::Red, *playerMtx);
 
                 if (siren != nullptr && siren->getActive())
                 {
                     if (flashFrequency1)
-                        DrawIcon(Blue, *playerMtx);
+                        DrawIcon(mmHudMap::Blue, *playerMtx);
 
                     if (flashFrequency2)
-                        DrawIcon(White, *playerMtx);
+                        DrawIcon(mmHudMap::White, *playerMtx);
                 }
             }
             else {
-                DrawIcon(Cyan, *playerMtx);
+                DrawIcon(mmHudMap::Cyan, *playerMtx);
             }
         }
         // Custom
@@ -2334,13 +2334,13 @@ void mmHudMapFeatureHandler::DrawCops() {
             if (hudMapColorStyle == 0)
             {
                 hudmap->SetIconScale(scaleAmount);
-                DrawIcon(Black, *policeMtx);
+                DrawIcon(mmHudMap::Black, *policeMtx);
                 hudmap->SetIconScale(iconScale);
 
                 if (police->Destroyed())
-                    DrawIcon(DarkRed, *policeMtx);
+                    DrawIcon(mmHudMap::DarkRed, *policeMtx);
                 else
-                    DrawIcon(BrightRed, *policeMtx);
+                    DrawIcon(mmHudMap::BrightRed, *policeMtx);
             }
             // MM1
             if (hudMapColorStyle == 1)
@@ -2348,62 +2348,62 @@ void mmHudMapFeatureHandler::DrawCops() {
                 hudmap->SetIconScale(scaleAmount);
 
                 if (police->Destroyed()) {
-                    DrawIcon(DarkBlue, *policeMtx);
+                    DrawIcon(mmHudMap::DarkBlue, *policeMtx);
                     hudmap->SetIconScale(iconScale);
-                    DrawIcon(DarkRed, *policeMtx);
+                    DrawIcon(mmHudMap::DarkRed, *policeMtx);
                 }
                 else {
-                    DrawIcon(Blue, *policeMtx);
+                    DrawIcon(mmHudMap::Blue, *policeMtx);
                     hudmap->SetIconScale(iconScale);
-                    DrawIcon(BrightRed, *policeMtx);
+                    DrawIcon(mmHudMap::BrightRed, *policeMtx);
                 }
             }
             // NFSHP2
             if (hudMapColorStyle == 2)
             {
                 hudmap->SetIconScale(scaleAmount);
-                DrawIcon(Black, *policeMtx);
+                DrawIcon(mmHudMap::Black, *policeMtx);
                 hudmap->SetIconScale(iconScale);
-                DrawIcon(Blue, *policeMtx);
+                DrawIcon(mmHudMap::Blue, *policeMtx);
 
                 if (police->InPersuit() && !police->Destroyed())
                 {
                     if (flashFrequency3)
-                        DrawIcon(BrightRed, *policeMtx);
+                        DrawIcon(mmHudMap::BrightRed, *policeMtx);
                 }
             }
             // NFSMW
             if (hudMapColorStyle == 3)
             {
                 hudmap->SetIconScale(scaleAmount);
-                DrawIcon(Black, *policeMtx);
+                DrawIcon(mmHudMap::Black, *policeMtx);
                 hudmap->SetIconScale(iconScale);
-                DrawIcon(White, *policeMtx);
+                DrawIcon(mmHudMap::White, *policeMtx);
 
                 if (police->InPersuit() && !police->Destroyed())
                 {
                     if (flashFrequency1)
-                        DrawIcon(Blue, *policeMtx);
+                        DrawIcon(mmHudMap::Blue, *policeMtx);
 
                     if (flashFrequency2)
-                        DrawIcon(BrightRed, *policeMtx);
+                        DrawIcon(mmHudMap::BrightRed, *policeMtx);
                 }
             }
             // NFSC
             if (hudMapColorStyle == 4)
             {
                 hudmap->SetIconScale(scaleAmount);
-                DrawIcon(Black, *policeMtx);
+                DrawIcon(mmHudMap::Black, *policeMtx);
                 hudmap->SetIconScale(iconScale);
-                DrawIcon(Red, *policeMtx);
+                DrawIcon(mmHudMap::Red, *policeMtx);
 
                 if (police->InPersuit() && !police->Destroyed())
                 {
                     if (flashFrequency1)
-                        DrawIcon(Blue, *policeMtx);
+                        DrawIcon(mmHudMap::Blue, *policeMtx);
 
                     if (flashFrequency2)
-                        DrawIcon(White, *policeMtx);
+                        DrawIcon(mmHudMap::White, *policeMtx);
                 }
             }
             // Custom
@@ -2436,44 +2436,44 @@ void mmHudMapFeatureHandler::DrawOpponents() {
             if (MMSTATE->Multiplayer)
             {
                 hudmap->SetIconScale(scaleAmount);
-                DrawIcon(Black, *opponentMtx);
+                DrawIcon(mmHudMap::Black, *opponentMtx);
                 hudmap->SetIconScale(iconScale);
 
                 if (oppIconInfo->Color == 0xFF0000EF)
                 {   
-                    DrawIcon(Blue, *opponentMtx);
+                    DrawIcon(mmHudMap::Blue, *opponentMtx);
                 }
                 if (oppIconInfo->Color == 0xFF00EF00)
                 {
-                    DrawIcon(Green, *opponentMtx);
+                    DrawIcon(mmHudMap::Green, *opponentMtx);
                 }
                 if (oppIconInfo->Color == 0xFFEF0000)
                 {
-                    DrawIcon(Red, *opponentMtx);
+                    DrawIcon(mmHudMap::Red, *opponentMtx);
                 }
                 if (oppIconInfo->Color == 0xFFFFFF00)
                 {
-                    DrawIcon(Yellow, *opponentMtx);
+                    DrawIcon(mmHudMap::Yellow, *opponentMtx);
                 }
                 if (oppIconInfo->Color == 0xFFFF5A00)
                 {
-                    DrawIcon(Orange, *opponentMtx);
+                    DrawIcon(mmHudMap::Orange, *opponentMtx);
                 }
                 if (oppIconInfo->Color == 0xFFB400FF)
                 {
-                    DrawIcon(Purple, *opponentMtx);
+                    DrawIcon(mmHudMap::Purple, *opponentMtx);
                 }
                 if (oppIconInfo->Color == 0xFF00FFFF)
                 {
-                    DrawIcon(Cyan, *opponentMtx);
+                    DrawIcon(mmHudMap::Cyan, *opponentMtx);
                 }
                 if (oppIconInfo->Color == 0xFFFF0390)
                 {
-                    DrawIcon(Pink, *opponentMtx);
+                    DrawIcon(mmHudMap::Pink, *opponentMtx);
                 }
                 if (oppIconInfo->Color == 0xFFFFFFFF)
                 {
-                    DrawIcon(White, *opponentMtx);
+                    DrawIcon(mmHudMap::White, *opponentMtx);
                 }
             }
             else {
@@ -2488,15 +2488,15 @@ void mmHudMapFeatureHandler::DrawOpponents() {
                     if (hudMapColorStyle == 0)
                     {
                         hudmap->SetIconScale(scaleAmount);
-                        DrawIcon(Black, *opponentMtx);
+                        DrawIcon(mmHudMap::Black, *opponentMtx);
                         hudmap->SetIconScale(iconScale);
-                        DrawIcon(Purple, *opponentMtx);
+                        DrawIcon(mmHudMap::Purple, *opponentMtx);
                     }
                     // MM1
                     if (hudMapColorStyle == 1)
                     {
                         hudmap->SetIconScale(scaleAmount);
-                        DrawIcon(Black, *opponentMtx);
+                        DrawIcon(mmHudMap::Black, *opponentMtx);
                         hudmap->SetIconScale(iconScale);
                         DrawIcon(i + 2, *opponentMtx);
                     }
@@ -2504,25 +2504,25 @@ void mmHudMapFeatureHandler::DrawOpponents() {
                     if (hudMapColorStyle == 2)
                     {
                         hudmap->SetIconScale(scaleAmount);
-                        DrawIcon(Black, *opponentMtx);
+                        DrawIcon(mmHudMap::Black, *opponentMtx);
                         hudmap->SetIconScale(iconScale);
-                        DrawIcon(Green, *opponentMtx);
+                        DrawIcon(mmHudMap::Green, *opponentMtx);
                     }
                     // NFSMW
                     if (hudMapColorStyle == 3)
                     {
                         hudmap->SetIconScale(scaleAmount);
-                        DrawIcon(Black, *opponentMtx);
+                        DrawIcon(mmHudMap::Black, *opponentMtx);
                         hudmap->SetIconScale(iconScale);
-                        DrawIcon(LightGreen, *opponentMtx);
+                        DrawIcon(mmHudMap::LightGreen, *opponentMtx);
                     }
                     // NFSC
                     if (hudMapColorStyle == 4)
                     {
                         hudmap->SetIconScale(scaleAmount);
-                        DrawIcon(Black, *opponentMtx);
+                        DrawIcon(mmHudMap::Black, *opponentMtx);
                         hudmap->SetIconScale(iconScale);
-                        DrawIcon(Orange, *opponentMtx);
+                        DrawIcon(mmHudMap::Orange, *opponentMtx);
                     }
                     // Custom
                     if (hudMapColorStyle >= 5)
@@ -2535,9 +2535,9 @@ void mmHudMapFeatureHandler::DrawOpponents() {
                 }
                 else {
                     hudmap->SetIconScale(scaleAmount);
-                    DrawIcon(Black, *opponentMtx);
+                    DrawIcon(mmHudMap::Black, *opponentMtx);
                     hudmap->SetIconScale(iconScale);
-                    DrawIcon(Grey, *opponentMtx);
+                    DrawIcon(mmHudMap::Grey, *opponentMtx);
                 }
             }
         }
@@ -2754,7 +2754,7 @@ void mmIconsFeatureHandler::Install() {
     InstallPatch({ 0x8C }, {
        0x432422 + 1, // mmIcons::Cull
     });
-    
+
     // Cull loop
     InstallPatch({ 0x8E }, {
        0x4328E2 + 1, // mmIcons::Cull

--- a/src/handlers/feature_handlers.h
+++ b/src/handlers/feature_handlers.h
@@ -163,12 +163,7 @@ public:
 class mmHudMapFeatureHandler {
 public:
     void DrawColoredTri(unsigned int color, const MM2::Matrix34 &matrix);
-    void DrawWhiteTri(const MM2::Matrix34 &matrix);
-    void DrawLightOrangeTri(const MM2::Matrix34 &matrix);
-    void DrawLightGreenTri(const MM2::Matrix34 &matrix);
     void DrawIcon(int iconType, const MM2::Matrix34 &matrix);
-    void DrawNfsMwPlayerIcon(const MM2::Matrix34 &matrix);
-    void DrawNfsMwOpponentIcon(const MM2::Matrix34 &matrix);
     void DrawPlayer();
     void DrawCops();
     void DrawOpponents();
@@ -176,11 +171,21 @@ public:
     static void Install();
 };
 
-class mmIconsHandler {
+class mmIconsFeatureHandler {
 public:
-    void RegisterOpponents(MM2::OppIconInfo *icons, int count, void *a3);
-    void RegisterOpponentsBlitz(MM2::OppIconInfo *icons, int count, void *a3);
+    void RegisterOpponents(MM2::OppIconInfo *icons, int count, void *font);
+    void RegisterOpponentsBlitz(MM2::OppIconInfo *icons, int count, void *font);
+    void RegisterOpponentsMulti(MM2::OppIconInfo *icons, int count, void *font);
 
+    static void Install();
+};
+
+class mmTextNodeHandler {
+public:
+    void GetTextDimensionsWhite(void const* a1, char const* a2, float& a3, float& a4);
+    void GetTextDimensionsBlack(void const* a1, char const* a2, float& a3, float& a4);
+    void AddTextWhite(void const* a1, char const* a2, int a3, float a4, float a5);
+    void AddTextBlack(void const* a1, char const* a2, int a3, float a4, float a5);
     static void Install();
 };
 

--- a/src/handlers/feature_handlers.h
+++ b/src/handlers/feature_handlers.h
@@ -163,7 +163,7 @@ public:
 class mmHudMapFeatureHandler {
 public:
     void DrawColoredTri(unsigned int color, const MM2::Matrix34 &matrix);
-    void DrawIcon(int iconType, const MM2::Matrix34 &matrix);
+    void DrawIcon(int iconColor, const MM2::Matrix34 &matrix);
     void DrawPlayer();
     void DrawCops();
     void DrawOpponents();

--- a/src/mm2_common.h
+++ b/src/mm2_common.h
@@ -364,7 +364,7 @@ namespace MM2 {
         int VehicleId;
 
         int InputDevice;
-        int unk_EC; // seems heavily tied into multiplayer, but also has singleplayer uses?
+        int Multiplayer; // if Zero that means we're in singleplayer otherwise we're in multiplayer
 
         BOOL CopsChaseAI; // cops will chase after opponents
         int unk_F4; // unused
@@ -546,6 +546,10 @@ namespace MM2 {
     declhook(0x6B4C24, _Type<int>, audDebug);
 
     declhook(0x6A3AC0, _Type<int>, gRandSeed);
+
+    declhook(0x6A3B18, _Type<Vector3>, XAXIS);
+    declhook(0x6A3B28, _Type<Vector3>, YAXIS);
+    declhook(0x6A3B38, _Type<Vector3>, ZAXIS);
 
     template<>
     void luaAddModule<module_common>(LuaState L) {

--- a/src/mm2_effects.h
+++ b/src/mm2_effects.h
@@ -48,4 +48,52 @@ namespace MM2
 
     // Allocated by vehCarModel::Init @ 0x4CD408, size 0x24
     ASSERT_SIZEOF(fxTexelDamage, 0x24);
+
+
+    class mmText {
+    public:
+        BYTE byte0;
+        BYTE byte1;
+
+        static AGE_API gfxBitmap* CreateFitBitmap(char const* text, void const* font, int color, int bgColor)
+        {
+            return hook::StaticThunk<0x532310>::Call<gfxBitmap*>(text, font, color, bgColor);
+        }
+    };
+
+    class mmTextData {
+    public:
+        Vector2 Pos;
+        uint32_t Flags;
+        HFONT Font;
+        char Text[256];
+    };
+
+    class mmTextNode : public asNode {
+    public:
+        Vector2 Pos;
+        uint32_t EntryCount;
+        uint32_t MaxEntries;
+        uint32_t DrawBits;
+        mmText dword2C;
+        mmTextData* pTextEntries;
+        gfxBitmap* Bitmap;
+        BOOL bModified;
+        uint32_t dword3C;
+        uint32_t dword40;
+        uint8_t byte44;
+        uint32_t FGColor;
+        uint32_t BGColor;
+        uint32_t HiglightColor;
+
+        AGE_API void GetTextDimensions(void const* a1, char const* a2, float& a3, float& a4)
+        {
+            hook::Thunk<0x532B10>::Call<void>(this, a1, a2, &a3, &a4);
+        }
+
+        AGE_API void AddText(void const* a1, char const* a2, int a3, float a4, float a5)
+        {
+            hook::Thunk<0x532C70>::Call<void>(this, a1, a2, a3, a4, a5);
+        }
+    };
 }

--- a/src/mm2_game.h
+++ b/src/mm2_game.h
@@ -1496,32 +1496,6 @@ namespace MM2
     };
     ASSERT_SIZEOF(mmWaypoints, 0x90);
 
-    enum HudmapIconColor {
-        Black,
-        BrightRed,
-        Blue,
-        Green,
-        Red,
-        Yellow,
-        Orange,
-        Purple,
-        Cyan,
-        Pink,
-        White,
-        LightOrange,
-        LightGreen,
-        DarkBlue,
-        DarkRed,
-        Grey,
-    };
-
-    enum HudmapMode {
-        Off,
-        Small,
-        HalfScreen,
-        FullScreen,
-    };
-
     class mmHudMap : public asNode {
     private:
         mmWaypoints* Waypoints;
@@ -1563,6 +1537,31 @@ namespace MM2
         AGE_API int GetNextMapMode()                        { return hook::Thunk<0x42EF00>::Call<int>(this); }
         AGE_API void SetMapMode(int a1)                     { hook::Thunk<0x42EF30>::Call<void>(this, a1); }
     public:
+        enum IconColor {
+            Black,
+            BrightRed,
+            Blue,
+            Green,
+            Red,
+            Yellow,
+            Orange,
+            Purple,
+            Cyan,
+            Pink,
+            White,
+            LightOrange,
+            LightGreen,
+            DarkBlue,
+            DarkRed,
+            Grey,
+        };
+
+        enum MapMode {
+            Off,
+            Small,
+            HalfScreen,
+            FullScreen,
+        };
 
         inline mmPlayer * GetPlayer()
         {

--- a/src/mm2_game.h
+++ b/src/mm2_game.h
@@ -1374,15 +1374,40 @@ namespace MM2
         int Color;
         bool Enabled;
         Matrix34* Matrix;
-        int field_C;
-        mmText* Text;
-        int field_14;
-        int field_18;
-        int field_1C;
+        int Place;
+        char Text[16];
         gfxBitmap* Bitmap;
-        int field_24;
+        float Scale;
     };
     ASSERT_SIZEOF(OppIconInfo, 0x28);
+
+    class mmIcons : public asNode {
+    private:
+        gfxTexture* IconTexture;
+        Matrix44 TriangleMtx;
+        Matrix44 IconMtx;
+        int OpponentCount;
+        float MinDistance;
+        float MaxDistance;
+        Matrix34* Transform;
+        OppIconInfo* IconInfo;
+        float field_B0;
+        int IconMode;
+        int field_B8;
+    public:
+        AGE_API void Init(Matrix34* camViewMtx, float minDist, float maxDist, int a4)
+                                                                    { hook::Thunk<0x432290>::Call<void>(this, camViewMtx, minDist, maxDist, a4); }
+        AGE_API void RegisterOpponents(OppIconInfo* icon, int count, void* font)
+                                                                    { hook::Thunk<0x4322F0>::Call<void>(this, icon, count, font); }
+
+        /*
+            asNode virtuals
+        */
+
+        virtual AGE_API void Cull() override                        { hook::Thunk<0x4323D0>::Call<void>(this); }
+        virtual AGE_API void Update() override                      { hook::Thunk<0x432390>::Call<void>(this); }
+    };
+    ASSERT_SIZEOF(mmIcons, 0xBC);
 
     class mmWaypointInstance : public lvlInstance {
     private:
@@ -1471,6 +1496,32 @@ namespace MM2
     };
     ASSERT_SIZEOF(mmWaypoints, 0x90);
 
+    enum HudmapIconColor {
+        Black,
+        BrightRed,
+        Blue,
+        Green,
+        Red,
+        Yellow,
+        Orange,
+        Purple,
+        Cyan,
+        Pink,
+        White,
+        LightOrange,
+        LightGreen,
+        DarkBlue,
+        DarkRed,
+        Grey,
+    };
+
+    enum HudmapMode {
+        Off,
+        Small,
+        HalfScreen,
+        FullScreen,
+    };
+
     class mmHudMap : public asNode {
     private:
         mmWaypoints* Waypoints;
@@ -1551,6 +1602,11 @@ namespace MM2
         inline short GetNumOpponents()
         {
             return this->NumOpponents;
+        }
+
+        inline int GetMapMode()
+        {
+            return this->MapMode;
         }
 
         AGE_API void Activate()                             { hook::Thunk<0x42EEE0>::Call<void>(this); }

--- a/src/mm2_ui.h
+++ b/src/mm2_ui.h
@@ -55,37 +55,6 @@ namespace MM2
         uint8_t A;
     };
 
-    class mmText {
-    public:
-        BYTE byte0;
-        BYTE byte1;
-    };
-
-    class mmTextData {
-    public:
-        Vector2 Pos;
-        uint32_t Flags;
-        HFONT Font;
-        char Text[256];
-    };
-
-    class mmTextNode : public asNode {
-        Vector2 Pos;
-        uint32_t EntryCount;
-        uint32_t MaxEntries;
-        uint32_t DrawBits;
-        mmText dword2C;
-        mmTextData *pTextEntries;
-        gfxBitmap *Bitmap;
-        BOOL bModified;
-        uint32_t dword3C;
-        uint32_t dword40;
-        uint8_t byte44;
-        uint32_t FGColor;
-        uint32_t BGColor;
-        uint32_t HiglightColor;
-    };
-
     class mmToolTip : public asNode {
         UIMenu *pParent;
         mmTextNode *pText;


### PR DESCRIPTION
mmHudMap:
- Cops use dark colors if they're destroyed for MM2 and MM1 styles.
- Enhanced cop radar blinking for NFSMW and NFSCarbon Styles.
- CnR teams affect player icons in Multiplayer.
- Added an option that changes CnR team colors from Red & Blue to Black & White.

mmIcons:
- Moved down place icon position a bit.
- 9th place icon no longer affects the gold icon now (use the new "opp_icon" texture).
- Added an option that changes CnR team colors from Red & Blue to Black & White.