### PR TITLE
Change burnout feature reference from MM1 to NFSMW

### DIFF
--- a/mm2hook.ini
+++ b/mm2hook.ini
@@ -59,7 +59,7 @@ PhysicalEngineDamage=0        ; Damage affects engine torque when the engine spe
 EnableMouseBar=0              ; Enables showing up the mouse bar for all input devices, this style is similar to the steering bar in Gran Turismo games.
 SwitchFromMPH2KPH=0           ; Allows you to switch hud speedometer from MPH to KPH.
 MM1StyleFlipOver=0            ; Modifies the way the car flips over itself in a way that resembles how Midtown Madness 1 did it.
-MM1StyleBurnout=0             ; Changes the way the cars get ready doing burnouts before the race starts in a way that resembles how Midtown Madness 1 did it.
+NFSMWStyleBurnout=0           ; Changes the way the cars get ready doing burnouts before the race starts in a way that resembles how NFS Most Wanted did it.
 UseRichPresence=1             ; Broadcast your current game mode, city, and vehicle on your Discord profile.
 EnableLua=0                   ; Enable the Lua script system. Always disabled in multiplayer.
 

--- a/src/handlers/feature_handlers.cpp
+++ b/src/handlers/feature_handlers.cpp
@@ -5113,7 +5113,7 @@ void dgBangerInstanceHandler::Install()
 static ConfigValue<bool> cfgVehicleDebug("VehicleDebug", "vehicleDebug", false);
 static ConfigValue<bool> cfgEnableWaterSplashSound("WaterSplashSound", true);
 static ConfigValue<bool> cfgEnableExplosionSound("ExplosionSound", true);
-static ConfigValue<bool> cfgMM1StyleBurnout("MM1StyleBurnout", false);
+static ConfigValue<bool> cfgNFSMWStyleBurnout("NFSMWStyleBurnout", false);
 bool enableWaterSplashSoundCached = true;
 bool enableExplosionSoundCached = true;
 bool fricValueChanged;
@@ -5395,7 +5395,7 @@ void vehCarHandler::Install(void) {
         );
     }
 
-    if (cfgMM1StyleBurnout.Get()) {
+    if (cfgNFSMWStyleBurnout.Get()) {
         InstallVTableHook("vehCar::PreUpdate",
             &PreUpdate, {
                 0x5B0BB4,


### PR DESCRIPTION
Due to MM1 lacks the way doing burnouts with AWD vehicles, we decided to change the feature reference to NFSMW instead because it has the same exact way of doing burnouts in this drivetrain type, so MM2 and NFSMW became identical to each other with this feature now.